### PR TITLE
Fix notifications checkbox callback

### DIFF
--- a/solar_comp/pages/profile.py
+++ b/solar_comp/pages/profile.py
@@ -87,7 +87,7 @@ def profile() -> rx.Component:
                 "Receive product updates",
                 size="3",
                 checked=ProfileState.profile.notifications,
-                on_change=ProfileState.toggle_notifications(),
+                on_change=ProfileState.toggle_notifications,
             ),
             width="100%",
             spacing="4",


### PR DESCRIPTION
## Summary
- ensure notification checkbox only triggers callback on change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b3275851483268e7bb5b3ff579f98