### PR TITLE
Refactor auth state usage

### DIFF
--- a/solar_comp/pages/auth/login.py
+++ b/solar_comp/pages/auth/login.py
@@ -34,9 +34,9 @@ def login_form() -> rx.Component:
         ),
         
         rx.cond(
-            AuthState.form_error,
+            AuthState.login_error,
             rx.text(
-                AuthState.form_error,
+                AuthState.login_error,
                 color="red.500",
                 size="sm",
                 mb=4,

--- a/solar_comp/pages/auth/register.py
+++ b/solar_comp/pages/auth/register.py
@@ -49,9 +49,9 @@ def register_form() -> rx.Component:
         ),
         
         rx.cond(
-            AuthState.form_error,
+            AuthState.login_error,
             rx.text(
-                AuthState.form_error,
+                AuthState.login_error,
                 color="red.500",
                 size="sm",
                 mb=4,


### PR DESCRIPTION
## Summary
- extend `AuthState` with a `login_error` attribute
- use stored form values for login and registration
- set the user name when logging in or registering
- adjust DB session creation to use `db_engine`
- show login errors in login/register pages

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: SyntaxError in unrelated file)*

------
https://chatgpt.com/codex/tasks/task_e_685b3274a3088326bc6587c98abe2d60