### PR TITLE
Add missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 reflex>=0.7.13a1
+sqlmodel
+bcrypt


### PR DESCRIPTION
## Summary
- add sqlmodel and bcrypt dependencies

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python solar_comp/solar_comp.py` *(fails: ModuleNotFoundError: No module named 'reflex')*

------
https://chatgpt.com/codex/tasks/task_e_685b3ad970d08326a2597f7491ece3fa